### PR TITLE
Fix missing healthbar in freshly loaded chunks.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,11 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
-minecraft_version=1.19.3
-yarn_mappings=1.19.3+build.3
-loader_version=0.14.11
+minecraft_version=1.19.4
+yarn_mappings=1.19.4+build.2
+loader_version=0.14.24
 #Fabric api
-fabric_version=0.69.1+1.19.3
-quilt_mappings=1
+fabric_version=0.87.1+1.19.4
 # Mod Properties
 mod_version=1.3.0
 maven_group=org.samo_lego

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ loader_version=0.14.24
 #Fabric api
 fabric_version=0.87.1+1.19.4
 # Mod Properties
-mod_version=1.3.0
+mod_version=1.3.2
 maven_group=org.samo_lego
 archives_base_name=healthcare
 # Dependencies

--- a/src/main/java/org/samo_lego/healthcare/mixin/ServerPlayNetworkHandlerMixin_HealthTag.java
+++ b/src/main/java/org/samo_lego/healthcare/mixin/ServerPlayNetworkHandlerMixin_HealthTag.java
@@ -81,9 +81,12 @@ public abstract class ServerPlayNetworkHandlerMixin_HealthTag {
             boolean doMutate = false;
 
             for (var p : bundledPackets.subPackets()){
-                if (p instanceof ClientboundSetEntityDataPacket dataPacket && (p=TryMutatePacket(dataPacket)) != null)
+                if (p instanceof ClientboundSetEntityDataPacket dataPacket && (dataPacket=TryMutatePacket(dataPacket)) != null){
                     doMutate = true;
-                packets.add(p);
+                    packets.add(dataPacket);
+                }
+                else
+                    packets.add(p);
             }
 
             if (doMutate)


### PR DESCRIPTION
Fixes an issue whereby healthbar would not immediately appear on mobs from a freshly loaded chunk. E.g, upon joining the world, changing dimension, or after traveling a long distance.

The injection in `sendPacket` now also scans the content of `ClientboundBundlePacket`'s. They contain packets that needed to be altered, and previously flew under the radar.

This PR is for 1.20. [This branch](/Estecka/mc-HealthCare/tree/healthbarInit%2B1.19.4) acts as a backport for 1.19.4